### PR TITLE
Removing hard-coded backslashes

### DIFF
--- a/src/main/com/smithsmodding/armory/weaponry/common/config/WeaponryConfigs.java
+++ b/src/main/com/smithsmodding/armory/weaponry/common/config/WeaponryConfigs.java
@@ -24,7 +24,7 @@ public class WeaponryConfigs
 
         public static void init(File file) {
             if (config == null) {
-                config = new Configuration(new File(file.getParentFile().getAbsolutePath() + "\\armory\\Addons\\weaponry.cfg"), true);
+                config = new Configuration(new File(file.getParentFile(), "armory/Addons/weaponry.cfg"), true);
                 loadWeaponryConfiguration();
             }
         }


### PR DESCRIPTION
Hard-coded backslashes caused creation of file called "config\armory\Addons\weaponry.cfg" in the root directory instead of putting the file in config/armory/Addons, when running on any OS other than Windows. Forward slashes work fine for all platforms in Java and thus is the obvious fix.

I have not checked other files in the repository for the same bug.